### PR TITLE
Parallelise encryption

### DIFF
--- a/benches/lwe_bench.rs
+++ b/benches/lwe_bench.rs
@@ -12,9 +12,17 @@ fn bench(c: &mut Criterion) {
 
     let encrypted = public.encrypt(&message);
 
-    c.bench_function("Encryption", |b: &mut Bencher| {
-        b.iter(|| public.encrypt(&message))
-    });
+    // c.bench_function("Secret Creation", |b: &mut Bencher| {
+    //     b.iter(|| Secret16::new())
+    // });
+    //
+    // c.bench_function("Pub Creation", |b: &mut Bencher| {
+    //     b.iter(|| secret.generate_public_key())
+    // });
+    //
+    // c.bench_function("Encryption", |b: &mut Bencher| {
+    //     b.iter(|| public.encrypt(&message))
+    // });
 
     c.bench_function("Decryption", |b: &mut Bencher| {
         b.iter(|| secret.decrypt(&encrypted))

--- a/benches/lwe_bench.rs
+++ b/benches/lwe_bench.rs
@@ -20,9 +20,9 @@ fn bench(c: &mut Criterion) {
     //     b.iter(|| secret.generate_public_key())
     // });
     //
-    // c.bench_function("Encryption", |b: &mut Bencher| {
-    //     b.iter(|| public.encrypt(&message))
-    // });
+    c.bench_function("Encryption", |b: &mut Bencher| {
+        b.iter(|| public.encrypt(&message))
+    });
 
     c.bench_function("Decryption", |b: &mut Bencher| {
         b.iter(|| secret.decrypt(&encrypted))

--- a/src/keys/public.rs
+++ b/src/keys/public.rs
@@ -1,5 +1,5 @@
 use rand::Rng;
-use rayon::prelude::ParallelSliceMut;
+use rayon::prelude::*;
 use zerocopy::{FromBytes, Immutable, IntoBytes};
 
 use crate::keys::modulus;
@@ -24,29 +24,30 @@ impl Public {
 
     pub fn encrypt(&self, message: &String) -> Vec<u8> {
         let dim = (self.dim + 1) as usize;
+        let pub_key_size = (self.dim * 10) as usize;
         let message_chars: Vec<char> = message.chars().collect();
         let len = message_chars.len();
         let mut encrypted: Vec<i32> = vec![0; dim * len];
-        let mut rng = rand::rng();
 
-        encrypted.par_chunks_mut(dim).enumerate().for_each(| (i, chunk) | {
-            let mut rng = rand::rng();
-            let char_num = (message_chars[i] as i32) * self.add;
-
-        });
-
-        for (i, chr) in message.chars().into_iter().enumerate() {
-            let chr_num = (chr as i32) * self.add;
-            for _ in 0..rng.random_range(2..3) {
-                let num = rng.random_range(0..self.dim * 10) as usize;
-                let slice = (num * dim)..(num * dim) + dim;
-                for (j, num) in self.key[slice].iter().enumerate() {
-                    encrypted[(i * dim) + j] += num;
+        encrypted
+            .par_chunks_mut(dim)
+            .zip(&message_chars)
+            .for_each(|(chunk, &chr)| {
+                let mut rng = rand::rng();
+                let char_num = (chr as i32) * self.add;
+                for _ in 0..rng.random_range(2..5) {
+                    let num = rng.random_range(0..pub_key_size);
+                    let slice = (num * dim)..(num * dim) + dim;
+                    for (key_num, chunk_num) in self.key[slice].iter().zip(&mut *chunk) {
+                        *chunk_num += key_num;
+                    }
                 }
-            }
-            encrypted[(i * dim) + dim - 1] =
-                modulus(encrypted[(i * dim) + dim - 1] + chr_num, self.modulo)
-        }
+
+                *chunk.last_mut().expect("encrypted buffer is empty") = modulus(
+                    chunk.last().expect("encrypted buffer is empty") + char_num,
+                    self.modulo,
+                );
+            });
 
         encrypted.as_bytes().to_vec()
     }

--- a/src/keys/public.rs
+++ b/src/keys/public.rs
@@ -1,4 +1,5 @@
 use rand::Rng;
+use rayon::prelude::ParallelSliceMut;
 use zerocopy::{FromBytes, Immutable, IntoBytes};
 
 use crate::keys::modulus;
@@ -23,9 +24,16 @@ impl Public {
 
     pub fn encrypt(&self, message: &String) -> Vec<u8> {
         let dim = (self.dim + 1) as usize;
-        let len = message.chars().count();
+        let message_chars: Vec<char> = message.chars().collect();
+        let len = message_chars.len();
         let mut encrypted: Vec<i32> = vec![0; dim * len];
         let mut rng = rand::rng();
+
+        encrypted.par_chunks_mut(dim).enumerate().for_each(| (i, chunk) | {
+            let mut rng = rand::rng();
+            let char_num = (message_chars[i] as i32) * self.add;
+
+        });
 
         for (i, chr) in message.chars().into_iter().enumerate() {
             let chr_num = (chr as i32) * self.add;

--- a/src/keys/secret.rs
+++ b/src/keys/secret.rs
@@ -41,10 +41,8 @@ impl Secret16 {
         let max_fuzz = add / 10;
         let neg_fuzz = -1 * max_fuzz;
 
-        for i in 0..170 {
-            for j in 0..17usize {
-                key[(i * 17) + j] = rng.random_range(-4096..4096);
-            }
+        for i in 0..key.len() {
+            key[i] = rng.random_range(-4096..4096);
         }
 
         for i in 0..170 {
@@ -66,6 +64,7 @@ impl Secret16 {
         let len = message.len() / dim;
         let mut answers: Vec<u32> = vec![0; len];
         let mut decrypted = String::with_capacity(len);
+        let add = self.add as f32;
 
         answers
             .par_iter_mut()
@@ -79,7 +78,7 @@ impl Secret16 {
                     .sum();
 
                 *expected = (modulus(message[(i * dim) + dim - 1] - chr_answer, self.modulo) as f32
-                    / self.add as f32)
+                    / add)
                     .round() as u32;
             });
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,19 +1,15 @@
 pub mod keys;
 
 use keys::secret::Secret16;
-use zerocopy::IntoBytes;
 
 fn main() {
     let secret = Secret16::new();
     let public = secret.generate_public_key();
 
-    let s_key = secret.as_bytes();
-    let p_key = public.as_bytes();
-    println!("Secret: {}", s_key.len());
-    println!("Secret: {}", p_key.len());
-
     let message = "Hello World!".to_string();
     let encrypted = public.encrypt(&message);
+
+    println!("{}", encrypted.len());
 
     let decrypted = secret.decrypt(&encrypted);
 


### PR DESCRIPTION
Using rayon's par_chunk_mut we have implemented an parallel version of encryption. 

Outcomes:
Encrypting a string of len 1000000 went from 40ms -> 29ms.